### PR TITLE
Fix `Producer.send` result value

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -70,8 +70,8 @@ Producer.prototype.partition_count = function(topic) {
 Producer.prototype.send = function(topic, partition, payloads) {
     var result = this.handle.send(topic, partition, payloads);
     return {
-        enqueued: result.enqueued,
-        send_queue_length: result.send_queue_length,
+        enqueued: result.queued,
+        send_queue_length: result.queue_length
     };
 }
 

--- a/specs/producer.js
+++ b/specs/producer.js
@@ -5,7 +5,7 @@ var Producer = require('../lib/producer').Producer;
 var testdata = require('./testdata');
 
 function make_raw_producer(send_fn, outq_fn) {
-    var clazz = function() { }
+    var clazz = function() { };
     clazz.prototype.send = function(topic, partition, payloads) {
         if (send_fn) {
             return send_fn(topic, partition, payloads);
@@ -45,7 +45,7 @@ describe('producer', function() {
         var test_topic = 'testtopic';
         var test_partition = 0;
         var test_payloads = ['hello','there'];
-        var test_result = {enqueued: 2, send_queue_length: 2};
+        var test_result = {queued: 2, queue_length: 2};
 
         var test = new ProducerTest({
             send: function(topic, partition, payloads) {
@@ -58,7 +58,8 @@ describe('producer', function() {
         });
         return Promise.try(function() {
             var result = test.producer.send(test_topic, test_partition, test_payloads);
-            expect(result).to.deep.equal(test_result);
+            expect(result.enqueued).to.equal(test_result.queued);
+            expect(result.send_queue_length).to.equal(test_result.queue_length);
         });
     });
 


### PR DESCRIPTION
I'm using `node-kafka-native` in a work-related project and noticed `Producer.send` returns a result object whose fields have _undefined_ as their value.

The fix was just to use the correct source field names; tests all pass but required a change:

The tests originally didn't fail because it looks like they only checked the structure of the mock and real result objects, not their values. They now check the values since the field names are different and the old test would otherwise always fail.

Thanks for taking the time to make this module public, it's very useful! Let me know if there are any issues with the pull request and I will address them.