### PR TITLE
Bugfix/gcc 4.6.x

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,7 +31,7 @@
             'libraries' : ['-lz']
           }
         ],[
-          'OS=="linux"',
+          'OS=="linux" and gcc_version>46',
           {
             'cflags': ['-std=c++11','-g'],
             'libraries' : ['-lz']

--- a/binding.gyp
+++ b/binding.gyp
@@ -25,6 +25,12 @@
             'libraries' : ['-lz']
           }
         ],[
+          'OS=="linux" and gcc_version<=46',
+          {
+            'cflags': ['-std=c++0x','-g'],
+            'libraries' : ['-lz']
+          }
+        ],[
           'OS=="linux"',
           {
             'cflags': ['-std=c++11','-g'],


### PR DESCRIPTION
Unfortunately this lib is not compiling with gcc version < 4.7 because of `-std=c++11` in cflags, but well - somebody still uses it ;-) I've added compatible cflags for older gcc version.